### PR TITLE
Fix wrong payload pointer after realloc

### DIFF
--- a/cantcoap.cpp
+++ b/cantcoap.cpp
@@ -1163,6 +1163,8 @@ uint8_t* CoapPDU::mallocPayload(int len) {
 			return NULL;
 		}
 		_pdu = newPDU;
+		// adjust payload pointer because realloc might have relocated PDU
+		_payloadPointer = &_pdu[_pduLength+1];
 		_bufferLength = newLen;
 	} else {
 		// constructed from buffer, check space


### PR DESCRIPTION
After reallocation of payload the payload pointer might point to wrong address. The realloc call can move the memory to somewhere else. In that case the payload pointer needs to be adjusted.